### PR TITLE
Fix off-by-one end column

### DIFF
--- a/src/Highlight/Parser.idr
+++ b/src/Highlight/Parser.idr
@@ -176,7 +176,7 @@ getRegion (SList xs) = do ([SString fn] ** _) <- decToMaybe (assoc (SSym "filena
                             | _ => Nothing
                           ([SInt el, SInt ec] ** _) <- decToMaybe (assoc (SSym "end") xs)
                             | _ => Nothing
-                          pure (MkRegion fn sl sc el ec ())
+                          pure (MkRegion fn sl sc el (1 + ec) ())
 getRegion _ = Nothing
 
 export


### PR DESCRIPTION
Hi there,

It looks like a recent change in Idris required to fix the end column calculation.
Looking at the Emacs mode, a similar patch have been applied: https://github.com/idris-hackers/idris-mode/issues/466.

Regards.
